### PR TITLE
Poppler backend: search for pdftopng in current environment

### DIFF
--- a/camelot/backends/poppler_backend.py
+++ b/camelot/backends/poppler_backend.py
@@ -1,10 +1,13 @@
+import os
+import sys
 import shutil
 import subprocess
 
+path = os.path.dirname(sys.executable) + os.pathsep + os.environ['PATH']
 
 class PopplerBackend:
     def convert(self, pdf_path, png_path):
-        pdftopng_executable = shutil.which("pdftopng")
+        pdftopng_executable = shutil.which("pdftopng", path=path)
         if pdftopng_executable is None:
             raise OSError(
                 "pdftopng is not installed. You can install it using the 'pip install pdftopng' command."


### PR DESCRIPTION
Fix situation where pdftopng is not found if executing python directly from an un-activated environment.