### PR TITLE
Use the absolute path to constraints.txt

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,0 +1,6 @@
+lockfile<0.13.0,>=0.12.2
+pip==23.2.1
+nox==2023.4.22
+nox-poetry==1.0.3
+poetry>=1.2.0
+virtualenv==20.24.5

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,6 +1,0 @@
-lockfile<0.13.0,>=0.12.2
-pip==23.2.1
-nox==2023.4.22
-nox-poetry==1.0.3
-poetry>=1.2.0
-virtualenv==20.24.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install pip
+          pip install --constraint=${PWD}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pip install poetry
+          pip install --constraint=${PWD}/.github/workflows/constraints.txt poetry
           poetry --version
 
       - name: Check if there is a parent commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pip install --constraint=.github/workflows/constraints.txt poetry
+          pip install poetry
           poetry --version
 
       - name: Check if there is a parent commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install pip
+          pip install --constraint=${PWD}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Upgrade pip in virtual environments
@@ -59,13 +59,13 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install poetry
+          pipx install --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install nox
-          pipx inject nox nox-poetry
+          pipx install --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
       - name: Install ghostscript
@@ -130,18 +130,18 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install pip
+          pip install --constraint=${PWD}/.github/workflows/constraints.txt pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pipx install poetry
+          pipx install --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install nox
-          pipx inject nox nox-poetry
+          pipx install --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt nox
+          pipx inject --pip-args=--constraint=${PWD}/.github/workflows/constraints.txt nox nox-poetry
           nox --version
 
       - name: Download coverage data

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install pip
           pip --version
 
       - name: Upgrade pip in virtual environments
@@ -59,13 +59,13 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pipx install poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install nox
+          pipx inject nox nox-poetry
           nox --version
 
       - name: Install ghostscript
@@ -130,18 +130,18 @@ jobs:
 
       - name: Upgrade pip
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
+          pip install pip
           pip --version
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pipx install poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install nox
+          pipx inject nox nox-poetry
           nox --version
 
       - name: Download coverage data


### PR DESCRIPTION
As described in https://github.com/cjolowicz/cookiecutter-hypermodern-python/issues/1383 there is an issue with pipx regarding relative paths. 

Using absolute paths fixes this. 