### PR TITLE
Fix CI: 🟢 mac-os specific ghostscript install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,13 @@ jobs:
           sudo apt update
           sudo apt install ghostscript
 
+      - name: Install ghostscript (macos-latest)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install ghostscript
+          mkdir -p ~/lib
+          ln -s "$(brew --prefix gs)/lib/libgs.dylib" ~/lib
+
       - name: Compute pre-commit cache key
         if: matrix.session == 'pre-commit'
         id: pre-commit-cache


### PR DESCRIPTION
Let's make CI 🟢 again.

 Thanks to this source: https://jonathansoma.com/everything/pdfs/camelot-ghostscript/