### PR TITLE
IMP Coverage: test to check unsupported file format

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -141,3 +141,10 @@ def test_lattice_ghostscript_deprecation_warning(foo_pdf):
         with pytest.raises(DeprecationWarning) as e:
             camelot.read_pdf(foo_pdf)
             assert str(e.value) == ghostscript_deprecation_warning
+
+
+def test_content_type():
+    url="https://camelot-py.readthedocs.io/en/master/_static/csv/foo.csv"
+    message = "File format not supported"
+    with pytest.raises(NotImplementedError, match=message):
+        tables = camelot.read_pdf(url)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -144,7 +144,7 @@ def test_lattice_ghostscript_deprecation_warning(foo_pdf):
 
 
 def test_content_type():
-    url="https://camelot-py.readthedocs.io/en/master/_static/csv/foo.csv"
+    url="https://pypdf-table-extraction.readthedocs.io/en/latest/_static/csv/foo.csv"
     message = "File format not supported"
     with pytest.raises(NotImplementedError, match=message):
         tables = camelot.read_pdf(url)


### PR DESCRIPTION
Added test to check if the error message is displayed accurately when an unsupported url is passed.

https://github.com/camelot-dev/camelot/pull/249