### PR TITLE
Add saturation threshold option for low contrast tables

### DIFF
--- a/camelot/cli.py
+++ b/camelot/cli.py
@@ -114,6 +114,12 @@ def cli(ctx, *args, **kwargs):
     "-back", "--process_background", is_flag=True, help="Process background lines."
 )
 @click.option(
+    "-color",
+    "--process_color_background",
+    is_flag=True,
+    help="Increase contrast for better background line processing.",
+)
+@click.option(
     "-scale",
     "--line_scale",
     default=40,

--- a/camelot/io.py
+++ b/camelot/io.py
@@ -70,6 +70,8 @@ def read_pdf(
         to generate columns.
     process_background* : bool, optional (default: False)
         Process background lines.
+    process_color_background* : bool, optional (default: False)
+        Increase contrast for better background line processing.
     line_scale* : int, optional (default: 40)
         Line size scaling factor. The larger the value the smaller
         the detected lines. Making it very large will lead to text

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -34,6 +34,10 @@ class Lattice(BaseParser):
         in PDF coordinate space.
     process_background : bool, optional (default: False)
         Process background lines.
+    process_color_background : bool, optional (default: False)
+        Increase contrast for better background line processing.
+    saturation_threshold : int, optional (default: 15)
+        Increase the saturation for better colored background line processing.
     line_scale : int, optional (default: 15)
         Line size scaling factor. The larger the value the smaller
         the detected lines. Making it very large will lead to text
@@ -85,6 +89,8 @@ class Lattice(BaseParser):
         table_regions=None,
         table_areas=None,
         process_background=False,
+        process_color_background=False,
+        saturation_threshold=5,
         line_scale=15,
         copy_text=None,
         shift_text=None,
@@ -105,6 +111,8 @@ class Lattice(BaseParser):
         self.table_regions = table_regions
         self.table_areas = table_areas
         self.process_background = process_background
+        self.process_color_background = process_color_background
+        self.saturation_threshold = saturation_threshold
         self.line_scale = line_scale
         self.copy_text = copy_text
         self.shift_text = shift_text or ["l", "t"]
@@ -230,6 +238,8 @@ class Lattice(BaseParser):
         self.pdf_image, self.threshold = adaptive_threshold(
             self.image_path,
             process_background=self.process_background,
+            process_color_background=self.process_color_background,
+            saturation_threshold=self.saturation_threshold,
             blocksize=self.threshold_blocksize,
             c=self.threshold_constant,
         )

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -130,6 +130,8 @@ common_kwargs = [
 text_kwargs = common_kwargs + ["columns", "edge_tol", "row_tol", "column_tol"]
 lattice_kwargs = common_kwargs + [
     "process_background",
+    "process_color_background",
+    "saturation_threshold",
     "line_scale",
     "copy_text",
     "shift_text",

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -35,6 +35,19 @@ To process background lines, you can pass ``process_background=True``.
   :file: ../_static/csv/background_lines.csv
   :class: full-width
 
+If there's too little contrast between the table background color and the document background color, you can try the option ``process_color_background=True``.
+
+.. code-block:: pycon
+
+    >>> tables = camelot.read_pdf('background_lines.pdf', process_background=True, process_color_background=True)
+    >>> tables[1].df
+
+.. tip::
+    Here's how you can do the same with the :ref:`command-line interface <cli>`.
+    ::
+
+        $ camelot lattice --process_color_background background_lines.pdf
+
 Visual debugging
 ----------------
 


### PR DESCRIPTION
Superseeding of: https://github.com/camelot-dev/camelot/pull/203

Would like the opinion of other contributors on this one.

![image](https://github.com/user-attachments/assets/80735dab-30e9-41c2-a22f-721a8dcfb891)


Here's with `process_color_background` option enabled:
![image](https://github.com/user-attachments/assets/21bae757-0c74-4e80-80a9-b7fcbc4a6668)



todo:
[ ] Add test file https://www.cima.ky/upimages/commonfiles/FraudulentWebsites-07June2023_1686164374.pdf
[ ] Unit test