### PR TITLE
[DEV] Run test workflow against main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
The test workflow is targeted to run against `master`, but the repo uses `main` so need to update that.