### PR TITLE
Simplify and fix `Table.set_span`

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -258,10 +258,6 @@ class Cell:
         Whether or not cell is bounded on the top.
     bottom : bool
         Whether or not cell is bounded on the bottom.
-    hspan : bool
-        Whether or not cell spans horizontally.
-    vspan : bool
-        Whether or not cell spans vertically.
     text : string
         Text assigned to cell.
 
@@ -280,8 +276,6 @@ class Cell:
         self.right = False
         self.top = False
         self.bottom = False
-        self.hspan = False
-        self.vspan = False
         self._text = ""
 
     def __repr__(self):
@@ -298,6 +292,16 @@ class Cell:
     @text.setter
     def text(self, t):
         self._text = "".join([self._text, t])
+
+    @property
+    def hspan(self) -> bool:
+        """Whether or not cell spans horizontally."""
+        return not self.left or not self.right
+
+    @property
+    def vspan(self) -> bool:
+        """Whether or not cell spans vertically."""
+        return not self.top or not self.bottom
 
     @property
     def bound(self):
@@ -527,18 +531,6 @@ class Table:
         for index, col in enumerate(self.cols):
             self.cells[0][index].top = True
             self.cells[len(self.rows) - 1][index].bottom = True
-        return self
-
-    def set_span(self):
-        """Sets a cell's hspan or vspan attribute to True depending
-        on whether the cell spans horizontally or vertically.
-        """
-        for row in self.cells:
-            for cell in row:
-                if not cell.left or not cell.right:
-                    cell.hspan = True
-                if not cell.top or not cell.bottom:
-                    cell.vspan = True
         return self
 
     def to_csv(self, path, **kwargs):

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -535,29 +535,10 @@ class Table:
         """
         for row in self.cells:
             for cell in row:
-                left = cell.left
-                right = cell.right
-                top = cell.top
-                bottom = cell.bottom
-                if cell.bound == 4:
-                    continue
-                elif cell.bound == 3:
-                    if not left and (right and top and bottom):
-                        cell.hspan = True
-                    elif not right and (left and top and bottom):
-                        cell.hspan = True
-                    elif not top and (left and right and bottom):
-                        cell.vspan = True
-                    elif not bottom and (left and right and top):
-                        cell.vspan = True
-                elif cell.bound == 2:
-                    if left and right and (not top and not bottom):
-                        cell.vspan = True
-                    elif top and bottom and (not left and not right):
-                        cell.hspan = True
-                elif cell.bound in [0, 1]:
-                    cell.vspan = True
+                if not cell.left or not cell.right:
                     cell.hspan = True
+                if not cell.top or not cell.bottom:
+                    cell.vspan = True
         return self
 
     def to_csv(self, path, **kwargs):

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -341,8 +341,6 @@ class Lattice(BaseParser):
         table = table.set_edges(v_s, h_s, joint_tol=self.joint_tol)
         # set table border edges to True
         table = table.set_border()
-        # set spanning cells to True
-        table = table.set_span()
 
         pos_errors = []
         # TODO: have a single list in place of two directional ones?

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -181,16 +181,16 @@ class Lattice(BaseParser):
         indices = []
         for r_idx, c_idx, text in idx:
             for d in shift_text:
-                if d == "l" and table.cells[r_idx][c_idx].hspan:
+                if d == "l":
                     while not table.cells[r_idx][c_idx].left:
                         c_idx -= 1
-                if d == "r" and table.cells[r_idx][c_idx].hspan:
+                elif d == "r":
                     while not table.cells[r_idx][c_idx].right:
                         c_idx += 1
-                if d == "t" and table.cells[r_idx][c_idx].vspan:
+                elif d == "t":
                     while not table.cells[r_idx][c_idx].top:
                         r_idx -= 1
-                if d == "b" and table.cells[r_idx][c_idx].vspan:
+                elif d == "b":
                     while not table.cells[r_idx][c_idx].bottom:
                         r_idx += 1
             indices.append((r_idx, c_idx, text))
@@ -219,13 +219,13 @@ class Lattice(BaseParser):
                 for i in range(len(table.cells)):
                     for j in range(len(table.cells[i])):
                         if table.cells[i][j].text.strip() == "":
-                            if table.cells[i][j].hspan and not table.cells[i][j].left:
+                            if not table.cells[i][j].left:
                                 table.cells[i][j].text = table.cells[i][j - 1].text
             elif f == "v":
                 for i in range(len(table.cells)):
                     for j in range(len(table.cells[i])):
                         if table.cells[i][j].text.strip() == "":
-                            if table.cells[i][j].vspan and not table.cells[i][j].top:
+                            if not table.cells[i][j].top:
                                 table.cells[i][j].text = table.cells[i - 1][j].text
         return table
 


### PR DESCRIPTION
In `Table.set_span` there are a bunch of redundant checks for borders and number of bordered edges that this commit simplifies. Additionally the vertical and horizontal spans are independent of each other, therefore these checks can be untangled.

I think that this actually uncovered a bug in the old implementation. For the cases where both horizontally and vertically only one of both edges are bordered there are differences with this commit.

| left  | right | top   | bottom | vspan/hspan before | vspan/hspan after |
| ----- | ----- | ---   | ------ | ------------------ | ----------------- |
| true  | false | true  | false  | false              | true              |
| true  | false | false | true   | false              | true              |
| false | true  | true  | false  | false              | true              |
| false | true  | false | true   | false              | true              |

This change in behaviour of the `Table.set_span` method is a bug fix. I guess in the original code it was missed that a cell could both horizontally and vertically span to other cells if the two bordered edges are not on the same direction.