### PR TITLE
use GTE (vs GT) in textedge intersection

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -66,7 +66,7 @@ class TextEdge:
             self.intersections += 1
             # a textedge is valid only if it extends uninterrupted
             # over a required number of textlines
-            if self.intersections > TEXTEDGE_REQUIRED_ELEMENTS:
+            if self.intersections >= TEXTEDGE_REQUIRED_ELEMENTS:
                 self.is_valid = True
 
 


### PR DESCRIPTION
Superseeding of: https://github.com/camelot-dev/camelot/pull/345 and https://github.com/foarsitter/camelot/pull/10
as reported in and fixes https://github.com/camelot-dev/camelot/pull/345