### PR TITLE
Speedup as in https://github.com/camelot-dev/camelot/issues/161

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -1,3 +1,4 @@
+import math
 import os
 import sqlite3
 import tempfile

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -60,7 +60,7 @@ class TextEdge:
         """Updates the text edge's x and bottom y coordinates and sets
         the is_valid attribute.
         """
-        if np.isclose(self.y0, y0, atol=edge_tol):
+        if math.isclose(self.y0, y0, atol=edge_tol):
             self.x = (self.intersections * self.x + x) / float(self.intersections + 1)
             self.y0 = y0
             self.intersections += 1
@@ -96,7 +96,7 @@ class TextEdges:
         the specified x coordinate and alignment.
         """
         for i, te in enumerate(self._textedges[align]):
-            if np.isclose(te.x, x_coord, atol=0.5):
+            if math.isclose(te.x, x_coord, atol=0.5):
                 return i
         return None
 

--- a/camelot/core.py
+++ b/camelot/core.py
@@ -61,7 +61,7 @@ class TextEdge:
         """Updates the text edge's x and bottom y coordinates and sets
         the is_valid attribute.
         """
-        if math.isclose(self.y0, y0, atol=edge_tol):
+        if math.isclose(self.y0, y0, abs_tol=edge_tol):
             self.x = (self.intersections * self.x + x) / float(self.intersections + 1)
             self.y0 = y0
             self.intersections += 1
@@ -97,7 +97,7 @@ class TextEdges:
         the specified x coordinate and alignment.
         """
         for i, te in enumerate(self._textedges[align]):
-            if math.isclose(te.x, x_coord, atol=0.5):
+            if math.isclose(te.x, x_coord, abs_tol=0.5):
                 return i
         return None
 


### PR DESCRIPTION
Speedup as in https://github.com/camelot-dev/camelot/issues/161

For reference: https://github.com/numpy/numpy/issues/16160

Seems still actual in 2024. My results:
```pycon
import timeit
print(timeit.timeit('np.isclose(0.5, 0, atol=1e-4)', 'import numpy as np', number=10000))
# 0.2664242945611477
print(timeit.timeit('math.isclose(0.5, 0, abs_tol=1e-4)', 'import math', number=10000))
# 0.001325499266386032
```

Once ready, prefer to squash and merge.

More performance gains could potentially be realized. But let's do that in a separate PR.
https://github.com/atlanhq/camelot/issues/427