### PR TITLE
[FIX]: Fix Github action: Coverage combine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ matplotlib = [
 
 
 [tool.coverage.paths]
-source = ["camelot", "*/site-packages"]
+source = ["camelot", "*\\camelot", "*/site-packages"]
 tests = ["tests", "*/tests"]
 
 [tool.coverage.run]


### PR DESCRIPTION
Fix coverage combine for windows and macos runner.

Fixes messages like this:

```
home/runner/work/pypdf_table_extraction/pypdf_table_extraction/.nox/coverage/lib/python3.10/site-packages/coverage/report_core.py:115: CoverageWarning: Couldn't parse '/home/runner/work/pypdf_table_extraction/pypdf_table_extraction/D:\a\pypdf_table_extraction\pypdf_table_extraction\camelot\plotting.py': No source for code: '/home/runner/work/pypdf_table_extraction/pypdf_table_extraction/D:\a\pypdf_table_extraction\pypdf_table_extraction\camelot\plotting.py'. (couldnt-parse)

```