### PR TITLE
[REF] slow np.isclose to math.isclose

### DIFF
--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -1,9 +1,9 @@
 """Defines a base parser. As well as generic methods for other parsers."""
 
+import math
 import os
 import warnings
 
-import numpy as np
 import pandas as pd
 
 from ..core import Table
@@ -319,7 +319,7 @@ class TextBaseParser(BaseParser):
             # if type(obj) is LTChar]):
             if row_y is None:
                 row_y = t.y0
-            elif not np.isclose(row_y, t.y0, atol=row_tol):
+            elif not math.isclose(row_y, t.y0, abs_tol=row_tol):
                 rows.append(sorted(temp, key=lambda t: t.x0))
                 temp = []
                 # We update the row's bottom as we go, to be forgiving if there
@@ -352,8 +352,8 @@ class TextBaseParser(BaseParser):
             else:
                 lower = merged[-1]
                 if column_tol >= 0:
-                    if higher[0] <= lower[1] or np.isclose(
-                        higher[0], lower[1], atol=column_tol
+                    if higher[0] <= lower[1] or math.isclose(
+                        higher[0], lower[1], abs_tol=column_tol
                     ):
                         upper_bound = max(lower[1], higher[1])
                         lower_bound = min(lower[0], higher[0])
@@ -362,7 +362,7 @@ class TextBaseParser(BaseParser):
                         merged.append(higher)
                 elif column_tol < 0:
                     if higher[0] <= lower[1]:
-                        if np.isclose(higher[0], lower[1], atol=abs(column_tol)):
+                        if math.isclose(higher[0], lower[1], abs_tol=abs(column_tol)):
                             merged.append(higher)
                         else:
                             upper_bound = max(lower[1], higher[1])

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1,6 +1,7 @@
 """General helper utilities to parse the pdf tables."""
 
 import atexit
+import math
 import os
 import random
 import re
@@ -855,7 +856,7 @@ def merge_close_lines(ar, line_tol=2):
             ret.append(a)
         else:
             temp = ret[-1]
-            if np.isclose(temp, a, atol=line_tol):
+            if math.isclose(temp, a, abs_tol=line_tol):
                 temp = (temp + a) / 2.0
                 ret[-1] = temp
             else:


### PR DESCRIPTION
Speedup as in https://github.com/camelot-dev/camelot/issues/161

For reference: https://github.com/numpy/numpy/issues/16160

Seems still actual in 2024. My results:
```pycon
import timeit
print(timeit.timeit('np.isclose(0.5, 0, atol=1e-4)', 'import numpy as np', number=10000))
# 0.2664242945611477
print(timeit.timeit('math.isclose(0.5, 0, abs_tol=1e-4)', 'import math', number=10000))
# 0.001325499266386032
```