### PR TITLE
remove sqlite as a strict dependency

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import math
 import os
-import sqlite3
 import tempfile
 import zipfile
 from operator import itemgetter
@@ -774,6 +773,7 @@ class Table:
             Output filepath.
 
         """
+        import sqlite3
         kw = {"if_exists": "replace", "index": False}
         kw.update(kwargs)
         conn = sqlite3.connect(path)


### PR DESCRIPTION
Note that sqlite3 wasn't installed by default for me when I ran `pip install pypdf-table-extraction[base]`, although I don't know if it's a dependency of tk or ghostscript. In any case, I don't think sqlite3 needs to be imported unless the `to_sqlite()` function is needed.