### PR TITLE
Network parser Fix B903

### DIFF
--- a/camelot/parsers/network.py
+++ b/camelot/parsers/network.py
@@ -46,6 +46,8 @@ class TextLine:
         The y-coordinate of the top edge of the text line.
     """
 
+    __slots__ = ("x0", "y0", "x1", "y1")
+
     def __init__(self, x0: float, y0: float, x1: float, y1: float):
         self.x0 = x0
         self.y0 = y0


### PR DESCRIPTION

This fixes Flake 8:

B903 Data class should either be immutable or use __slots__ to save memory. Use collections.namedtuple to generate an immutable class, or enumerate the attributes in a __slot__ declaration in the class to leave attributes mutable.