### PR TITLE
[REF] remove_unconnected_edges

### DIFF
--- a/camelot/parsers/network.py
+++ b/camelot/parsers/network.py
@@ -387,24 +387,38 @@ class TextNetworks(TextAlignments):
         Elements should be connected to others both vertically
         and horizontally.
         """
+        # Initialize a flag to indicate if any singletons were removed
         removed_singletons = True
+
         while removed_singletons:
             removed_singletons = False
+
             for text_alignments in self._text_alignments.values():
                 # For each alignment edge, remove items if they are singletons
                 # either horizontally or vertically
                 for text_alignment in text_alignments:
-                    for i in range(len(text_alignment.textlines) - 1, -1, -1):
+                    # Create a list to hold textlines to be removed
+                    to_remove = []
+
+                    for i in range(len(text_alignment.textlines)):
                         textline = text_alignment.textlines[i]
                         alignments = self._textline_to_alignments[textline]
+
+                        # Check if the textline is a singleton in either direction
                         if (
                             alignments.max_h_count() <= 1
                             or alignments.max_v_count() <= 1
                         ):
-                            del text_alignment.textlines[i]
-                            removed_singletons = True
+                            to_remove.append(i)  # Mark for removal
+
+                    # Remove items after iterating to avoid modifying the list during iteration
+                    for index in reversed(to_remove):
+                        del text_alignment.textlines[index]
+                        removed_singletons = True
+
+            # Clear the alignment cache
             self._textline_to_alignments = {}
-            self._compute_alignment_counts()
+            self._compute_alignment_counts()  # Recompute alignment counts after removals
 
     def most_connected_textline(self):
         """Retrieve the textline that is most connected."""


### PR DESCRIPTION
1. **Using a Separate List for Removal**: Instead of deleting elements from `text_alignment.textlines` while iterating over it, we first collect the indices of elements to remove in a separate list called `to_remove`. This prevents issues that can arise from modifying a list while iterating over it.

2. **Reverse Index Removal**: When removing items, we iterate over `to_remove` in reverse order. This ensures that the indices of elements to be removed do not affect the remaining elements in the list as we delete them.

3. **Clearer Condition for Removal**: The condition checking whether a text line is a singleton remains the same, but moving the deletion logic outside of the inner loop improves clarity and avoids potential errors that could lead to infinite loops.

4. **Termination Flag**: The loop continues as long as `removed_singletons` is `True`, which indicates that at least one text line has been removed in the last iteration. If no text lines are removed in a complete pass through the alignments, the loop will exit.

5. **Recomputing Alignments**: The line `self._textline_to_alignments = {}` is retained to clear the cache of alignments before recomputing them. This ensures that the latest state is reflected after modifications.