### PR TITLE
[REF]: core set_border: Improve performance, Fix index out of Range

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -726,12 +726,31 @@ class Table:
 
     def set_border(self):
         """Sets table border edges to True."""
-        for index, _row in enumerate(self.rows):
-            self.cells[index][0].left = True
-            self.cells[index][len(self.cols) - 1].right = True
-        for index, _col in enumerate(self.cols):
-            self.cells[0][index].top = True
-            self.cells[len(self.rows) - 1][index].bottom = True
+        num_rows = len(self.rows)
+        num_cols = len(self.cols)
+
+        # Ensure cells structure is valid
+        if num_rows == 0 or num_cols == 0:
+            return self  # No rows or columns, nothing to do
+
+        # Check if cells have the expected structure
+        if len(self.cells) != num_rows or any(
+            len(row) != num_cols for row in self.cells
+        ):
+            raise ValueError(
+                "Inconsistent cells structure: cells should match the dimensions of rows and cols."
+            )
+
+        # Set left and right borders for each row
+        for row_index in range(num_rows):
+            self.cells[row_index][0].left = True  # Set the left border
+            self.cells[row_index][num_cols - 1].right = True  # Set the right border
+
+        # Set top and bottom borders for each column
+        for col_index in range(num_cols):
+            self.cells[0][col_index].top = True  # Set the top border
+            self.cells[num_rows - 1][col_index].bottom = True  # Set the bottom border
+
         return self
 
     def copy_spanning_text(self, copy_text=None):


### PR DESCRIPTION
1. **Variable Initialization**: We store `len(self.rows)` and `len(self.cols)` in `num_rows` and `num_cols` respectively to avoid recalculating these values on each iteration.

2. **Error Handling**: Before trying to set borders, we check if the number of rows and columns is valid. If either is zero, the method returns early. Additionally, we check if `self.cells` has the expected structure. If not, we raise a `ValueError`.

3. **Looping through Indices**: Instead of using `enumerate()`, use a simple `range()` loop since we only need the index and not the item itself. This can enhance readability and possibly performance.