### PR TITLE
[FIX] hybrid Keyerror

### DIFF
--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -236,7 +236,16 @@ class BaseParser:
         """Record data about the origin of the table."""
         table.flavor = self.id
         table.filename = self.filename
-        table.parse = self.table_bbox_parses[table._bbox]
+        if table._bbox in self.table_bbox_parses:
+            table.parse = self.table_bbox_parses[table._bbox]
+        else:
+            # Handle the KeyError gracefully by returning empty lists
+            # or by performing alternative logic, such as using a default
+            # bounding box or skipping the table.
+            print(
+                f"Warning: Bounding box {table._bbox} not found in table_bbox_parses."
+            )
+            return [], [], [], []  # Return empty lists for cols, rows, v_s, h_s
         table.parse_details = self.parse_details
         pos_errors = self.compute_parse_errors(table)
         table.accuracy = compute_accuracy([[100, pos_errors]])

--- a/camelot/parsers/network.py
+++ b/camelot/parsers/network.py
@@ -936,13 +936,21 @@ class Network(TextBaseParser):
             cols = [text_x_min] + user_cols + [text_x_max]
             cols = [(cols[i], cols[i + 1]) for i in range(0, len(cols) - 1)]
         else:
-            parse_details = self.table_bbox_parses[bbox]
-            col_anchors = parse_details["cols_anchors"]
-            cols = list(
-                map(
-                    lambda idx: [col_anchors[idx], col_anchors[idx + 1]],
-                    range(0, len(col_anchors) - 1),
+            # Check if the bounding box exists as a key in the dictionary
+            if bbox in self.table_bbox_parses:
+                parse_details = self.table_bbox_parses[bbox]
+                col_anchors = parse_details["cols_anchors"]
+                cols = list(
+                    map(
+                        lambda idx: [col_anchors[idx], col_anchors[idx + 1]],
+                        range(0, len(col_anchors) - 1),
+                    )
                 )
-            )
+            else:
+                # Handle the KeyError gracefully by returning empty lists
+                # or by performing alternative logic, such as using a default
+                # bounding box or skipping the table.
+                print(f"Warning: Bounding box {bbox} not found in table_bbox_parses.")
+                return [], [], [], []  # Return empty lists for cols, rows, v_s, h_s
 
         return cols, rows, None, None

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -133,3 +133,10 @@ def test_hybrid_layout_kwargs(testdir):
         filename, flavor="hybrid", layout_kwargs={"detect_vertical": False}
     )
     assert_frame_equal(df, tables[0].df)
+
+
+def test_hybrid_keyerror(testdir):
+    """Parsing this PDF generates a key error."""
+    filename = os.path.join(testdir, "tabula/schools.pdf")
+    tables = camelot.read_pdf(filename, flavor="hybrid", pages="4-5")
+    assert len(tables) >= 1


### PR DESCRIPTION
The first commit is introducing a unit test which was failling with a Keyerror.

The second commit is rather a workaround then a fix.
It let's the parser fail/continue gracefully.
Whichi is desired when using this library in a ETL/Document flow when processing multiple pages.

