### PR TITLE
[IMP] reduce pdf object loop

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -18,9 +18,9 @@ from .parsers import Network
 from .parsers import Stream
 from .utils import TemporaryDirectory
 from .utils import download_url
+from .utils import get_char_and_text_objects
 from .utils import get_page_layout
 from .utils import get_rotation
-from .utils import get_text_objects
 from .utils import is_url
 
 
@@ -156,9 +156,7 @@ class PDFHandler:
             outfile.write(f)
         layout, dimensions = get_page_layout(fpath, **layout_kwargs)
         # fix rotated PDF
-        chars = get_text_objects(layout, ltype="char")
-        horizontal_text = get_text_objects(layout, ltype="horizontal_text")
-        vertical_text = get_text_objects(layout, ltype="vertical_text")
+        chars, horizontal_text, vertical_text = get_char_and_text_objects(layout)
         rotation = get_rotation(chars, horizontal_text, vertical_text)
         if rotation != "":
             fpath_new = "".join([froot.replace("page", "p"), "_rotated", fext])

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -10,8 +10,6 @@ from ..core import Table
 from ..utils import bbox_from_str
 from ..utils import compute_accuracy
 from ..utils import compute_whitespace
-from ..utils import get_image_and_text_objects
-from ..utils import get_page_layout
 from ..utils import get_table_index
 from ..utils import text_in_bbox
 
@@ -63,17 +61,26 @@ class BaseParser:
         """
         return sorted(self.table_bbox_parses.keys(), key=lambda x: x[1], reverse=True)
 
-    def prepare_page_parse(self, filename, layout, dimensions, page_idx, layout_kwargs):
+    def prepare_page_parse(
+        self,
+        filename,
+        layout,
+        dimensions,
+        page_idx,
+        images,
+        horizontal_text,
+        vertical_text,
+        layout_kwargs,
+    ):
         """Prepare the page for parsing."""
         self.filename = filename
         self.layout_kwargs = layout_kwargs
         self.layout = layout
         self.dimensions = dimensions
         self.page = page_idx
-        self.layout, self.dimensions = get_page_layout(filename, **layout_kwargs)
-        self.images, self.horizontal_text, self.vertical_text = (
-            get_image_and_text_objects(self.layout)
-        )
+        self.images = images
+        self.horizontal_text = horizontal_text
+        self.vertical_text = vertical_text
         self.pdf_width, self.pdf_height = self.dimensions
         self.rootname, __ = os.path.splitext(self.filename)
 

--- a/camelot/parsers/base.py
+++ b/camelot/parsers/base.py
@@ -10,8 +10,9 @@ from ..core import Table
 from ..utils import bbox_from_str
 from ..utils import compute_accuracy
 from ..utils import compute_whitespace
+from ..utils import get_image_and_text_objects
+from ..utils import get_page_layout
 from ..utils import get_table_index
-from ..utils import get_text_objects
 from ..utils import text_in_bbox
 
 
@@ -69,9 +70,10 @@ class BaseParser:
         self.layout = layout
         self.dimensions = dimensions
         self.page = page_idx
-        self.images = get_text_objects(self.layout, ltype="image")
-        self.horizontal_text = get_text_objects(self.layout, ltype="horizontal_text")
-        self.vertical_text = get_text_objects(self.layout, ltype="vertical_text")
+        self.layout, self.dimensions = get_page_layout(filename, **layout_kwargs)
+        self.images, self.horizontal_text, self.vertical_text = (
+            get_image_and_text_objects(self.layout)
+        )
         self.pdf_width, self.pdf_height = self.dimensions
         self.rootname, __ = os.path.splitext(self.filename)
 

--- a/camelot/parsers/hybrid.py
+++ b/camelot/parsers/hybrid.py
@@ -92,7 +92,17 @@ class Hybrid(BaseParser):
             debug=debug,
         )
 
-    def prepare_page_parse(self, filename, layout, dimensions, page_idx, layout_kwargs):
+    def prepare_page_parse(
+        self,
+        filename,
+        layout,
+        dimensions,
+        page_idx,
+        images,
+        horizontal_text,
+        vertical_text,
+        layout_kwargs,
+    ):
         """Call this method to prepare the page parsing .
 
         Parameters
@@ -109,13 +119,34 @@ class Hybrid(BaseParser):
             [description]
         """
         super().prepare_page_parse(
-            filename, layout, dimensions, page_idx, layout_kwargs
+            filename,
+            layout,
+            dimensions,
+            page_idx,
+            images,
+            horizontal_text,
+            vertical_text,
+            layout_kwargs,
         )
         self.network_parser.prepare_page_parse(
-            filename, layout, dimensions, page_idx, layout_kwargs
+            filename,
+            layout,
+            dimensions,
+            page_idx,
+            images,
+            horizontal_text,
+            vertical_text,
+            layout_kwargs,
         )
         self.lattice_parser.prepare_page_parse(
-            filename, layout, dimensions, page_idx, layout_kwargs
+            filename,
+            layout,
+            dimensions,
+            page_idx,
+            images,
+            horizontal_text,
+            vertical_text,
+            layout_kwargs,
         )
 
     def _generate_columns_and_rows(self, bbox, table_idx):

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1434,3 +1434,126 @@ def get_text_objects(layout, ltype="char", t=None):
     except AttributeError:
         pass
     return t
+
+
+def get_char_and_text_objects(
+    layout: LTContainer,
+) -> Tuple[List[LTChar], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+    """Parse a pdf layout to get text objects.
+
+    Recursively parses pdf layout to get a list of
+    PDFMiner LTChar, LTTextLineHorizontal, LTTextLineVertical objects.
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object
+            ( LTPage, LTTextLineHorizontal, LTTextLineVertical).
+
+    Returns
+    -------
+    result : tuple
+        Include List of LTChar objects, list of LTTextLineHorizontal objects
+        and list of LTTextLineVertical objects
+
+    """
+    char = []
+    horizontal_text = []
+    vertical_text = []
+
+    try:
+        for _object in layout:
+            if isinstance(_object, LTChar):
+                char.append(_object)
+            elif isinstance(_object, LTTextLineHorizontal):
+                horizontal_text.append(_object)
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+            elif isinstance(_object, LTTextLineVertical):
+                vertical_text.append(_object)
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+            elif isinstance(_object, LTContainer):
+                child_char, child_horizontal_text, child_vertical_text = (
+                    get_char_and_text_objects(_object)
+                )
+                char.extend(child_char)
+                horizontal_text.extend(child_horizontal_text)
+                vertical_text.extend(child_vertical_text)
+    except AttributeError:
+        pass
+    return char, horizontal_text, vertical_text
+
+
+def get_char_objects(layout: LTContainer) -> List[LTChar]:
+    """Get charachter objects from a pdf layout.
+
+    Recursively parses pdf layout to get a list of PDFMiner LTChar
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object.
+
+    Returns
+    -------
+    result : list
+        List of LTChar text objects.
+
+    """
+    char = []
+    try:
+        for _object in layout:
+            if isinstance(_object, LTChar):
+                char.append(_object)
+            elif isinstance(_object, LTContainer):
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
+    except AttributeError:
+        pass
+    return char
+
+
+def get_image_and_text_objects(
+    layout: LTContainer,
+) -> Tuple[List[LTImage], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+    """Parse a PDF layout to get objects.
+
+    Recursively parses pdf layout to get a list of
+    PDFMiner LTImage, LTTextLineHorizontal, LTTextLineVertical objects.
+
+    Parameters
+    ----------
+    layout : object
+        PDFMiner LTContainer object
+            ( LTPage, LTTextLineHorizontal, LTTextLineVertical).
+
+    Returns
+    -------
+    result : tuple
+        Include List of LTImage objects, list of LTTextLineHorizontal objects
+        and list of LTTextLineVertical objects
+
+    """
+    image = []
+    horizontal_text = []
+    vertical_text = []
+
+    try:
+        for _object in layout:
+            if isinstance(_object, LTImage):
+                image.append(_object)
+            elif isinstance(_object, LTTextLineHorizontal):
+                horizontal_text.append(_object)
+            elif isinstance(_object, LTTextLineVertical):
+                vertical_text.append(_object)
+            elif isinstance(_object, LTContainer):
+                child_image, child_horizontal_text, child_vertical_text = (
+                    get_char_and_text_objects(_object)
+                )
+                image.extend(child_image)
+                horizontal_text.extend(child_horizontal_text)
+                vertical_text.extend(child_vertical_text)
+    except AttributeError:
+        pass
+    return image, horizontal_text, vertical_text

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1399,55 +1399,6 @@ def get_page_layout(
         return layout, dim
 
 
-def get_char_and_text_objects(
-    layout: LTContainer[LTItem],
-) -> tuple[list[LTChar], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
-    """Parse a pdf layout to get text objects.
-
-    Recursively parses pdf layout to get a list of
-    PDFMiner LTChar, LTTextLineHorizontal, LTTextLineVertical objects.
-
-    Parameters
-    ----------
-    layout : object
-        PDFMiner LTContainer object
-            ( LTPage, LTTextLineHorizontal, LTTextLineVertical).
-
-    Returns
-    -------
-    result : tuple
-        Include List of LTChar objects, list of LTTextLineHorizontal objects
-        and list of LTTextLineVertical objects
-
-    """
-    char = []
-    horizontal_text = []
-    vertical_text = []
-
-    try:
-        for _object in layout:
-            if isinstance(_object, LTChar):
-                char.append(_object)
-            elif isinstance(_object, LTTextLineHorizontal):
-                horizontal_text.append(_object)
-                child_char = get_char_objects(_object)
-                char.extend(child_char)
-            elif isinstance(_object, LTTextLineVertical):
-                vertical_text.append(_object)
-                child_char = get_char_objects(_object)
-                char.extend(child_char)
-            elif isinstance(_object, LTContainer):
-                child_char, child_horizontal_text, child_vertical_text = (
-                    get_char_and_text_objects(_object)
-                )
-                char.extend(child_char)
-                horizontal_text.extend(child_horizontal_text)
-                vertical_text.extend(child_vertical_text)
-    except AttributeError:
-        pass
-    return char, horizontal_text, vertical_text
-
-
 def get_char_objects(layout: LTContainer[Any]) -> list[LTChar]:
     """Get charachter objects from a pdf layout.
 
@@ -1477,9 +1428,11 @@ def get_char_objects(layout: LTContainer[Any]) -> list[LTChar]:
     return char
 
 
-def get_image_and_text_objects(
+def get_image_char_and_text_objects(
     layout: LTContainer[LTItem],
-) -> tuple[list[LTImage], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
+) -> tuple[
+    list[LTImage], list[LTChar], list[LTTextLineHorizontal], list[LTTextLineVertical]
+]:
     """Parse a PDF layout to get objects.
 
     Recursively parses pdf layout to get a list of
@@ -1499,6 +1452,7 @@ def get_image_and_text_objects(
 
     """
     image = []
+    char = []
     horizontal_text = []
     vertical_text = []
 
@@ -1510,13 +1464,17 @@ def get_image_and_text_objects(
                 horizontal_text.append(_object)
             elif isinstance(_object, LTTextLineVertical):
                 vertical_text.append(_object)
+            if isinstance(_object, LTChar):
+                char.append(_object)
             elif isinstance(_object, LTContainer):
-                child_image, child_horizontal_text, child_vertical_text = (
-                    get_image_and_text_objects(_object)
+                child_image, child_char, child_horizontal_text, child_vertical_text = (
+                    get_image_char_and_text_objects(_object)
                 )
                 image.extend(child_image)
+                child_char = get_char_objects(_object)
+                char.extend(child_char)
                 horizontal_text.extend(child_horizontal_text)
                 vertical_text.extend(child_vertical_text)
     except AttributeError:
         pass
-    return image, horizontal_text, vertical_text
+    return image, char, horizontal_text, vertical_text

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -28,6 +28,7 @@ from pdfminer.converter import PDFPageAggregator
 from pdfminer.layout import LAParams
 from pdfminer.layout import LTAnno
 from pdfminer.layout import LTChar
+from pdfminer.layout import LTContainer
 from pdfminer.layout import LTImage
 from pdfminer.layout import LTTextLine
 from pdfminer.layout import LTTextLineHorizontal
@@ -1438,7 +1439,7 @@ def get_text_objects(layout, ltype="char", t=None):
 
 def get_char_and_text_objects(
     layout: LTContainer,
-) -> Tuple[List[LTChar], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+) -> tuple[list[LTChar], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
     """Parse a pdf layout to get text objects.
 
     Recursively parses pdf layout to get a list of
@@ -1485,7 +1486,7 @@ def get_char_and_text_objects(
     return char, horizontal_text, vertical_text
 
 
-def get_char_objects(layout: LTContainer) -> List[LTChar]:
+def get_char_objects(layout: LTContainer) -> list[LTChar]:
     """Get charachter objects from a pdf layout.
 
     Recursively parses pdf layout to get a list of PDFMiner LTChar
@@ -1516,7 +1517,7 @@ def get_char_objects(layout: LTContainer) -> List[LTChar]:
 
 def get_image_and_text_objects(
     layout: LTContainer,
-) -> Tuple[List[LTImage], List[LTTextLineHorizontal], List[LTTextLineVertical]]:
+) -> tuple[list[LTImage], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
     """Parse a PDF layout to get objects.
 
     Recursively parses pdf layout to get a list of

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -1399,45 +1399,6 @@ def get_page_layout(
         return layout, dim
 
 
-def get_text_objects(layout, ltype="char", t=None):
-    """Recursively parses pdf layout to get a list of PDFMiner text objects.
-
-    Parameters
-    ----------
-    layout : object
-        PDFMiner LTPage object.
-    ltype : string
-        Specify 'char', 'lh', 'lv' to get LTChar, LTTextLineHorizontal,
-        and LTTextLineVertical objects respectively.
-    t : list
-
-    Returns
-    -------
-    t : list
-        List of PDFMiner text objects.
-
-    """
-    if ltype == "char":
-        LTObject = LTChar  # noqa
-    elif ltype == "image":
-        LTObject = LTImage  # noqa
-    elif ltype == "horizontal_text":
-        LTObject = LTTextLineHorizontal  # noqa
-    elif ltype == "vertical_text":
-        LTObject = LTTextLineVertical  # noqa
-    if t is None:
-        t = []
-    try:
-        for obj in layout._objs:
-            if isinstance(obj, LTObject):  # noqa
-                t.append(obj)
-            else:
-                t += get_text_objects(obj, ltype=ltype)
-    except AttributeError:
-        pass
-    return t
-
-
 def get_char_and_text_objects(
     layout: LTContainer[LTItem],
 ) -> tuple[list[LTChar], list[LTTextLineHorizontal], list[LTTextLineVertical]]:

--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -30,6 +30,7 @@ from pdfminer.layout import LTAnno
 from pdfminer.layout import LTChar
 from pdfminer.layout import LTContainer
 from pdfminer.layout import LTImage
+from pdfminer.layout import LTItem
 from pdfminer.layout import LTTextLine
 from pdfminer.layout import LTTextLineHorizontal
 from pdfminer.layout import LTTextLineVertical
@@ -1438,7 +1439,7 @@ def get_text_objects(layout, ltype="char", t=None):
 
 
 def get_char_and_text_objects(
-    layout: LTContainer,
+    layout: LTContainer[LTItem],
 ) -> tuple[list[LTChar], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
     """Parse a pdf layout to get text objects.
 
@@ -1486,7 +1487,7 @@ def get_char_and_text_objects(
     return char, horizontal_text, vertical_text
 
 
-def get_char_objects(layout: LTContainer) -> list[LTChar]:
+def get_char_objects(layout: LTContainer[Any]) -> list[LTChar]:
     """Get charachter objects from a pdf layout.
 
     Recursively parses pdf layout to get a list of PDFMiner LTChar
@@ -1516,7 +1517,7 @@ def get_char_objects(layout: LTContainer) -> list[LTChar]:
 
 
 def get_image_and_text_objects(
-    layout: LTContainer,
+    layout: LTContainer[LTItem],
 ) -> tuple[list[LTImage], list[LTTextLineHorizontal], list[LTTextLineVertical]]:
     """Parse a PDF layout to get objects.
 
@@ -1550,7 +1551,7 @@ def get_image_and_text_objects(
                 vertical_text.append(_object)
             elif isinstance(_object, LTContainer):
                 child_image, child_horizontal_text, child_vertical_text = (
-                    get_char_and_text_objects(_object)
+                    get_image_and_text_objects(_object)
                 )
                 image.extend(child_image)
                 horizontal_text.extend(child_horizontal_text)

--- a/pypdf_table_extraction/utils.py
+++ b/pypdf_table_extraction/utils.py
@@ -16,9 +16,8 @@ from camelot.utils import expand_bbox_with_textline  # noqa F401
 from camelot.utils import find_columns_boundaries  # noqa F401
 from camelot.utils import flag_font_size  # noqa F401
 from camelot.utils import flavor_to_kwargs  # noqa F401
-from camelot.utils import get_char_and_text_objects  # noqa F401
 from camelot.utils import get_char_objects  # noqa F401
-from camelot.utils import get_image_and_text_objects  # noqa F401
+from camelot.utils import get_image_char_and_text_objects  # noqa F401
 from camelot.utils import get_index_closest_point  # noqa F401
 from camelot.utils import get_page_layout  # noqa F401
 from camelot.utils import get_rotation  # noqa F401

--- a/pypdf_table_extraction/utils.py
+++ b/pypdf_table_extraction/utils.py
@@ -16,11 +16,13 @@ from camelot.utils import expand_bbox_with_textline  # noqa F401
 from camelot.utils import find_columns_boundaries  # noqa F401
 from camelot.utils import flag_font_size  # noqa F401
 from camelot.utils import flavor_to_kwargs  # noqa F401
+from camelot.utils import get_char_and_text_objects  # noqa F401
+from camelot.utils import get_char_objects  # noqa F401
+from camelot.utils import get_image_and_text_objects  # noqa F401
 from camelot.utils import get_index_closest_point  # noqa F401
 from camelot.utils import get_page_layout  # noqa F401
 from camelot.utils import get_rotation  # noqa F401
 from camelot.utils import get_table_index  # noqa F401
-from camelot.utils import get_text_objects  # noqa F401
 from camelot.utils import get_textline_coords  # noqa F401
 from camelot.utils import is_url  # noqa F401
 from camelot.utils import lattice_kwargs  # noqa F401


### PR DESCRIPTION

Originally, Camelot scans 2 to 3 times for whole PDF objects on the page to get 1. Horizontal Texts, 2. Vertical texts, and 3. Images.
This PR is to change it to one scan to get everything.

This is a port of https://github.com/nexus-lib/camelot/pull/1