### PR TITLE
:bomb:  Make Ghostscript an optional dependency :sparkles: 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -880,20 +880,6 @@ unicode = ["unicodedata2 (>=15.1.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
-name = "ghostscript"
-version = "0.7"
-description = "Interface to the Ghostscript C-API, both high- and low-level, based on ctypes"
-optional = false
-python-versions = "*"
-files = [
-    {file = "ghostscript-0.7-py2.py3-none-any.whl", hash = "sha256:97c70e27ba6b1cab4ab1d9b4cc82d89b8b53e57971f608ded4950b8aa20c78a7"},
-    {file = "ghostscript-0.7.tar.gz", hash = "sha256:b7875a87098740eb0be3de2d9662d15db727305ca9a6d4b7534a3cc33a4b965a"},
-]
-
-[package.dependencies]
-setuptools = ">=38.6.0"
-
-[[package]]
 name = "identify"
 version = "2.6.1"
 description = "File identification library for Python"
@@ -3144,4 +3130,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "22af33f6ed4de2dc6ef544d362b3f4519c4f5297dae0a4befdb624a126027e67"
+content-hash = "96a8bdfde414e2eb078dc0d68349893b92b653399953749fa5a9cf1612d49579"

--- a/poetry.lock
+++ b/poetry.lock
@@ -880,6 +880,20 @@ unicode = ["unicodedata2 (>=15.1.0)"]
 woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
+name = "ghostscript"
+version = "0.7"
+description = "Interface to the Ghostscript C-API, both high- and low-level, based on ctypes"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ghostscript-0.7-py2.py3-none-any.whl", hash = "sha256:97c70e27ba6b1cab4ab1d9b4cc82d89b8b53e57971f608ded4950b8aa20c78a7"},
+    {file = "ghostscript-0.7.tar.gz", hash = "sha256:b7875a87098740eb0be3de2d9662d15db727305ca9a6d4b7534a3cc33a4b965a"},
+]
+
+[package.dependencies]
+setuptools = ">=38.6.0"
+
+[[package]]
 name = "identify"
 version = "2.6.1"
 description = "File identification library for Python"
@@ -3130,4 +3144,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "96a8bdfde414e2eb078dc0d68349893b92b653399953749fa5a9cf1612d49579"
+content-hash = "b97713a279a9687cfb03f3960b9f3ce942ab6d5e885fbf224173d0e6fd20fc64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,12 @@ matplotlib = [
     {version = "^3.8.0", python = ">=3.12"}
 ]
 
+[tool.poetry.group.ghostscript]
+optional = true
+
+[tool.poetry.group.ghostscript.dependencies]
+ghostscript = "^0.7"
+
 [tool.poetry_bumpversion.file."camelot/__version__.py"]
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ camelot = "camelot.__main__:main"
 pypdf_table_extraction = "pypdf_table_extraction.__main__:main"
 
 [tool.poetry.group.base.dependencies]
-ghostscript = "^0.7"
 opencv-python-headless = "^4.7.0.68"
 pypdfium2 = "^4"
 


### PR DESCRIPTION
PDFium is now used as the standard image conversion backend.
Making it easier to install on a lot of systems by just using the pip package manager.

The ghostscript backend is still available. but moved to an optional dependency group.
It can be installed with `poetry install --with ghostscript`.

Documentation will be updated in a separate pr. Before the next major release.